### PR TITLE
Fix Demo links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Syntax highlighting for Dart and Flutter, which supports lots of languages and themes.
 
-[View gallery built with Flutter web](https://pd4d10.github.io/highlight/)
+[View gallery built with Flutter web](https://git-touch.github.io/highlight/)
 
 | Package                                                                                | Version                                                                                              | Description                                      |
 | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------ |

--- a/flutter_highlight/CHANGELOG.md
+++ b/flutter_highlight/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0+1
+
+- Update demo link
+
 ## 0.6.0
 
 - Specify Tab size

--- a/flutter_highlight/README.md
+++ b/flutter_highlight/README.md
@@ -2,7 +2,7 @@
 
 [![pub](https://img.shields.io/pub/v/flutter_highlight)](https://pub.dev/packages/flutter_highlight)
 
-Syntax highlighter for Flutter. https://pd4d10.github.io/highlight/
+Syntax highlighter for Flutter. https://git-touch.github.io/highlight/
 
 ## Usage
 

--- a/flutter_highlight/pubspec.yaml
+++ b/flutter_highlight/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutter_highlight
 description: Syntax highlighting widget for Flutter with lots of languages and themes support.
-version: 0.6.0
+version: 0.6.0+1
 author: Rongjian Zhang <pd4d10@gmail.com>
-homepage: https://github.com/pd4d10/highlight
+homepage: https://github.com/git-touch/highlight
 
 environment:
   sdk: ">=2.3.0 <3.0.0"


### PR DESCRIPTION
The demos could not be reached via the old link anymore, hence, I updated it to `git-touch`.